### PR TITLE
Reindex element segment expressions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ wasmparser = "0.235.0"
 [dev-dependencies]
 wasmprinter = "0.235.0"
 wat = "1.227.1"
+wasmtime = "34.0.1"

--- a/src/ir/module/module_tables.rs
+++ b/src/ir/module/module_tables.rs
@@ -99,12 +99,13 @@ impl<'a> Table<'a> {
 }
 
 #[derive(Clone, Debug)]
-pub struct Element<'a> {
-    pub kind: ElementKind<'a>,
-    pub items: ElementItems<'a>,
+pub struct Element {
+    pub kind: ElementKind,
+    pub items: ElementItems,
     tag: InjectTag,
 }
-impl TagUtils for Element<'_> {
+
+impl TagUtils for Element {
     fn get_or_create_tag(&mut self) -> &mut Tag {
         self.tag.get_or_insert_default()
     }
@@ -113,8 +114,9 @@ impl TagUtils for Element<'_> {
         &self.tag
     }
 }
-impl<'a> Element<'a> {
-    pub fn new(kind: ElementKind<'a>, items: ElementItems<'a>, tag: InjectTag) -> Self {
+
+impl Element {
+    pub fn new(kind: ElementKind, items: ElementItems, tag: InjectTag) -> Self {
         Self { kind, items, tag }
     }
 }


### PR DESCRIPTION
This change applies the global and function reindexing to the contents of element segments. Previously they were only reindexed if the element segment's items were parsed as `wasmparser::ElementItems::Functions`, but not if they were parsed as `wasmparser::ElementItems::Expresions`.