### PR TITLE
Re-export wasmparser for easier type compatibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,3 +21,7 @@ pub use crate::ir::types::DataSegmentKind;
 pub use crate::ir::types::DataType;
 pub use crate::ir::types::InitInstr;
 pub use crate::ir::types::Location;
+
+// Re-export wasmparser so users can have the same types for e.g.
+// `wasmparser::Operator` as we use internally.
+pub use wasmparser;


### PR DESCRIPTION
This change adds a public re-export of the `wasmparser` crate in `lib.rs`, allowing users to access the same wasmparser types (like `wasmparser::Operator`) that are used internally by `wirm`. This improves type compatibility and reduces the need for users to keep their version of `wasmparser` synced to the version used by `wirm`.