### PR TITLE
Add some more iterators for Module fields

### DIFF
--- a/src/ir/module/module_exports.rs
+++ b/src/ir/module/module_exports.rs
@@ -51,8 +51,18 @@ impl ModuleExports {
         ModuleExports { exports }
     }
 
+    /// Iterate over all the exports in the module.
+    ///     
+    /// Note that exports may have been deleted.
     pub fn iter(&self) -> std::slice::Iter<'_, Export> {
         self.exports.iter()
+    }
+
+    /// Iterate over the exports in the module.
+    ///     
+    /// Note that exports may have been deleted.
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, Export> {
+        self.exports.iter_mut()
     }
 
     /// Checks if there are no exports

--- a/src/ir/module/module_functions.rs
+++ b/src/ir/module/module_functions.rs
@@ -322,6 +322,13 @@ impl<'a> Functions<'a> {
     pub fn iter(&self) -> impl Iterator<Item = &Function<'a>> {
         Iter::<Function<'a>>::iter(self)
     }
+
+    /// Iterate over functions present in the module
+    ///
+    /// Note: Functions returned by this iterator *may* be deleted.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Function<'a>> {
+        self.functions.iter_mut()
+    }
 }
 
 impl<'a> Iter<Function<'a>> for Functions<'a> {

--- a/src/ir/module/module_memories.rs
+++ b/src/ir/module/module_memories.rs
@@ -49,6 +49,20 @@ impl Memories {
         }
     }
 
+    /// Iterate over the memories in the module.
+    ///     
+    /// Note that memories may have been deleted.
+    pub fn iter(&self) -> std::slice::Iter<'_, Memory> {
+        <Self as Iter<Memory>>::iter(self)
+    }
+
+    /// Iterate over the memories in the module.
+    ///     
+    /// Note that memories may have been deleted.
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, Memory> {
+        self.memories.iter_mut()
+    }
+
     /// Get a memory by its MemoryID
     pub fn get_mem_by_id(&self, mem_id: MemoryID) -> Option<&Memory> {
         if *mem_id < self.memories.len() as u32 {


### PR DESCRIPTION
Implement mutable iterators for `functions`, `exports` and `memories` and read-only iterators for `memories`.

These can make it more ergonomic to apply a transformation to all entries in the field.