### PR TITLE
Add Global::kind method

### DIFF
--- a/src/ir/module/module_globals.rs
+++ b/src/ir/module/module_globals.rs
@@ -131,6 +131,10 @@ impl Global {
     fn delete(&mut self) {
         self.deleted = true;
     }
+
+    pub fn kind(&self) -> &GlobalKind {
+        &self.kind
+    }
 }
 
 /// The globals section of a module


### PR DESCRIPTION
Add an accessor for the `kind` field of a `Global`. We can currently read the `kind` from the `ModuleGlobals` if we have the `GlobalID` via `get_kind`, but this just makes it cleaner if you already have a `Global` to get the `kind` directly.