### PR TITLE
Remove `String` leaks by changing arguments for adding imports

### DIFF
--- a/fac_wirm/src/main.rs
+++ b/fac_wirm/src/main.rs
@@ -4,16 +4,16 @@
 //! You can run this wasm file with `fact.js`
 
 use wirm::ir::function::FunctionBuilder;
+use wirm::ir::id::LocalID;
 use wirm::ir::module::*;
 use wirm::ir::types::*;
-use wirm::opcode::Opcode;
 use wirm::module_builder::AddLocal;
-use wirm::ir::id::LocalID;
+use wirm::opcode::Opcode;
 
 fn main() {
     let mut module = Module::default();
     let log_type_id = module.types.add_func_type(&[DataType::I32], &[]);
-    let (log_func_id, _) = module.add_import_func("env".to_string(), "log".to_string(), log_type_id);
+    let (log_func_id, _) = module.add_import_func("env", "log", log_type_id);
 
     let mut factorial = FunctionBuilder::new(&[DataType::I32], &[DataType::I32]);
 
@@ -62,7 +62,9 @@ fn main() {
     let fact_id = factorial.finish_module(&mut module);
 
     // Export the `factorial` function.
-    module.exports.add_export_func("factorial".to_string(), *fact_id);
+    module
+        .exports
+        .add_export_func("factorial".to_string(), *fact_id);
 
     module.emit_wasm("target/out.wasm").unwrap();
 

--- a/src/ir/module/mod.rs
+++ b/src/ir/module/mod.rs
@@ -1898,8 +1898,8 @@ impl<'a> Module<'a> {
     /// Add a local memory to the module with an appended tag.
     pub fn add_import_memory(
         &mut self,
-        module: String,
-        name: String,
+        module: &'a str,
+        name: &'a str,
         ty: MemoryType,
     ) -> (MemoryID, ImportsID) {
         self.add_import_memory_with_tag(module, name, ty, Tag::default())
@@ -1907,14 +1907,14 @@ impl<'a> Module<'a> {
     /// Add an imported memory to the module with an appended tag.
     pub fn add_import_memory_with_tag(
         &mut self,
-        module: String,
-        name: String,
+        module: &'a str,
+        name: &'a str,
         ty: MemoryType,
         tag: Tag,
     ) -> (MemoryID, ImportsID) {
         let (imp_mem_id, imp_id) = self.add_import(Import {
-            module: module.leak(),
-            name: name.clone().leak(),
+            module,
+            name,
             ty: TypeRef::Memory(ty),
             custom_name: None,
             deleted: false,
@@ -1968,8 +1968,8 @@ impl<'a> Module<'a> {
     /// - ImportsID: The ID that indexes into the import section.
     pub fn add_import_func(
         &mut self,
-        module: String,
-        name: String,
+        module: &'a str,
+        name: &'a str,
         ty_id: TypeID,
     ) -> (FunctionID, ImportsID) {
         self.add_import_func_with_tag(module, name, ty_id, Tag::default())
@@ -1981,14 +1981,14 @@ impl<'a> Module<'a> {
     /// - ImportsID: The ID that indexes into the import section.
     pub fn add_import_func_with_tag(
         &mut self,
-        module: String,
-        name: String,
+        module: &'a str,
+        name: &'a str,
         ty_id: TypeID,
         tag: Tag,
     ) -> (FunctionID, ImportsID) {
         let (imp_fn_id, imp_id) = self.add_import(Import {
-            module: module.leak(),
-            name: name.clone().leak(),
+            module,
+            name,
             ty: TypeRef::Func(*ty_id),
             custom_name: None,
             deleted: false,
@@ -1997,7 +1997,7 @@ impl<'a> Module<'a> {
 
         // Add to functions as well as it has imported functions
         self.functions
-            .add_import_func(imp_id, ty_id, Some(name), imp_fn_id);
+            .add_import_func(imp_id, ty_id, Some(name.to_string()), imp_fn_id);
         (FunctionID(imp_fn_id), imp_id)
     }
 
@@ -2042,8 +2042,8 @@ impl<'a> Module<'a> {
     pub fn convert_local_fn_to_import(
         &mut self,
         function_id: FunctionID,
-        module: String,
-        name: String,
+        module: &'a str,
+        name: &'a str,
         ty_id: TypeID,
     ) -> bool {
         self.convert_local_fn_to_import_with_tag(function_id, module, name, ty_id, Tag::default())
@@ -2055,8 +2055,8 @@ impl<'a> Module<'a> {
     pub fn convert_local_fn_to_import_with_tag(
         &mut self,
         function_id: FunctionID,
-        module: String,
-        name: String,
+        module: &'a str,
+        name: &'a str,
         ty_id: TypeID,
         tag: Tag,
     ) -> bool {
@@ -2068,8 +2068,8 @@ impl<'a> Module<'a> {
         self.delete_func(function_id);
         // Add import function to imports
         let (.., import_id) = self.add_import(Import {
-            module: module.leak(),
-            name: name.clone().leak(),
+            module,
+            name,
             ty: TypeRef::Func(*ty_id),
             custom_name: None,
             deleted: false,
@@ -2082,7 +2082,9 @@ impl<'a> Module<'a> {
                 import_fn_id: function_id,
                 ty_id,
             }));
-        assert!(self.functions.set_imported_fn_name(function_id, name));
+        assert!(self
+            .functions
+            .set_imported_fn_name(function_id, name.to_string()));
         true
     }
 
@@ -2149,8 +2151,8 @@ impl<'a> Module<'a> {
     /// - ImportsID: The ID that indexes into the import section.
     pub fn add_imported_global(
         &mut self,
-        module: String,
-        name: String,
+        module: &'a str,
+        name: &'a str,
         content_ty: DataType,
         mutable: bool,
         shared: bool,
@@ -2164,8 +2166,8 @@ impl<'a> Module<'a> {
     /// - ImportsID: The ID that indexes into the import section.
     pub fn add_imported_global_with_tag(
         &mut self,
-        module: String,
-        name: String,
+        module: &'a str,
+        name: &'a str,
         content_ty: DataType,
         mutable: bool,
         shared: bool,
@@ -2177,8 +2179,8 @@ impl<'a> Module<'a> {
             shared,
         };
         let (imp_global_id, imp_id) = self.add_import(Import {
-            module: module.leak(),
-            name: name.leak(),
+            module,
+            name,
             ty: TypeRef::Global(global_ty),
             custom_name: None,
             deleted: false,

--- a/src/ir/module/test.rs
+++ b/src/ir/module/test.rs
@@ -44,7 +44,7 @@ fn test_add_import_func() {
     state_assertions(&module, &init_state, false);
 
     // add imported func
-    let (fid, imp0) = module.add_import_func("test0".to_string(), "func0".to_string(), TypeID(0));
+    let (fid, imp0) = module.add_import_func("test0", "func0", TypeID(0));
     assert_eq!(init_state.next_fid(), *fid); // zero-based, no '+ 1'
     assert_eq!(init_state.next_imp_id(), *imp0); // zero-based, no '+ 1'
     init_state.add_imported_func();
@@ -72,7 +72,7 @@ fn test_add_local_then_imported_func() {
     init_state.add_local_func();
 
     // add imported func
-    let (fid, imp0) = module.add_import_func("test0".to_string(), "func0".to_string(), TypeID(0));
+    let (fid, imp0) = module.add_import_func("test0", "func0", TypeID(0));
     assert_eq!(init_state.next_fid(), *fid); // zero-based, no '+ 1'
     assert_eq!(init_state.next_imp_id(), *imp0); // zero-based, no '+ 1'
     init_state.add_imported_func();
@@ -93,7 +93,7 @@ fn test_add_imported_then_local_func() {
     state_assertions(&module, &init_state, false);
 
     // add imported func
-    let (fid, imp0) = module.add_import_func("test0".to_string(), "func0".to_string(), TypeID(0));
+    let (fid, imp0) = module.add_import_func("test0", "func0", TypeID(0));
     assert_eq!(init_state.next_fid(), *fid); // zero-based, no '+ 1'
     assert_eq!(init_state.next_imp_id(), *imp0); // zero-based, no '+ 1'
     init_state.add_imported_func();
@@ -170,7 +170,7 @@ fn test_add_then_delete_imported_func() {
     state_assertions(&module, &init_state, false);
 
     // add imported func
-    let (fid, imp0) = module.add_import_func("test0".to_string(), "func0".to_string(), TypeID(0));
+    let (fid, imp0) = module.add_import_func("test0", "func0", TypeID(0));
     assert_eq!(init_state.next_fid(), *fid); // zero-based, no '+ 1'
     assert_eq!(init_state.next_imp_id(), *imp0); // zero-based, no '+ 1'
     init_state.add_imported_func();
@@ -269,12 +269,7 @@ fn test_convert_local_fn_to_import() {
     state_assertions(&module, &init_state, false);
 
     // convert local func to import
-    module.convert_local_fn_to_import(
-        FunctionID(52),
-        "please".to_string(),
-        "work".to_string(),
-        TypeID(1),
-    ); // unused in wat file!
+    module.convert_local_fn_to_import(FunctionID(52), "please", "work", TypeID(1)); // unused in wat file!
     init_state.local_func_to_import();
 
     is_valid(
@@ -449,13 +444,8 @@ fn test_add_imported_global() {
     state_assertions(&module, &init_state, false);
 
     // add an imported global
-    let (gid, imp_id) = module.add_imported_global(
-        "knock knock".to_string(),
-        "gimme a global".to_string(),
-        DataType::I32,
-        true,
-        false,
-    );
+    let (gid, imp_id) =
+        module.add_imported_global("knock knock", "gimme a global", DataType::I32, true, false);
     assert_eq!(init_state.next_gid(), *gid);
     assert_eq!(init_state.next_imp_id(), *imp_id);
     init_state.add_imported_global();

--- a/tests/func_builder.rs
+++ b/tests/func_builder.rs
@@ -74,7 +74,7 @@ fn add_import_and_local_fn_then_iterate() {
     let wasm = wat::parse_file(file_name).expect("couldn't convert the input wat to Wasm");
     let mut module = Module::parse(&wasm, false).expect("Unable to parse");
     // add an imported function AND THEN a new local function
-    module.add_import_func("new".to_string(), "import".to_string(), TypeID(0));
+    module.add_import_func("new", "import", TypeID(0));
     assert_eq!(module.num_import_func(), 1);
 
     let params = vec![];

--- a/tests/instrumentation_test.rs
+++ b/tests/instrumentation_test.rs
@@ -1697,8 +1697,8 @@ fn add_imports_when_has_start_func() {
     let buff = wat::parse_file(file).expect("couldn't convert the input wat to Wasm");
     let mut module = Module::parse(&buff, false).expect("Unable to parse");
 
-    module.add_import_func("ima".to_string(), "new_import".to_string(), TypeID(0));
-    module.add_import_func("ya_dont".to_string(), "say".to_string(), TypeID(0));
+    module.add_import_func("ima", "new_import", TypeID(0));
+    module.add_import_func("ya_dont", "say", TypeID(0));
 
     let result = module.encode();
     let out = wasmprinter::print_bytes(result).expect("couldn't translate wasm to wat");

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -328,7 +328,7 @@ fn test_add_import() {
     let buff = wat::parse_file(file).expect("couldn't convert the input wat to Wasm");
     let mut module = Module::parse(&buff, false).expect("Unable to parse module");
 
-    module.add_import_func("wirm".to_string(), "better".to_string(), TypeID(2));
+    module.add_import_func("wirm", "better", TypeID(2));
 
     check_validity(
         file,
@@ -345,12 +345,7 @@ fn test_middle_local_to_import() {
     let buff = wat::parse_file(file).expect("couldn't convert the input wat to Wasm");
     let mut module = Module::parse(&buff, false).expect("Unable to parse module");
 
-    module.convert_local_fn_to_import(
-        FunctionID(2),
-        "wirm".to_string(),
-        "better".to_string(),
-        TypeID(2),
-    );
+    module.convert_local_fn_to_import(FunctionID(2), "wirm", "better", TypeID(2));
 
     check_validity(
         file,
@@ -367,12 +362,7 @@ fn test_first_local_to_import() {
     let buff = wat::parse_file(file).expect("couldn't convert the input wat to Wasm");
     let mut module = Module::parse(&buff, false).expect("Unable to parse module");
 
-    module.convert_local_fn_to_import(
-        FunctionID(1),
-        "wirm".to_string(),
-        "better".to_string(),
-        TypeID(2),
-    );
+    module.convert_local_fn_to_import(FunctionID(1), "wirm", "better", TypeID(2));
 
     check_validity(
         file,
@@ -389,12 +379,7 @@ fn test_last_local_to_import() {
     let buff = wat::parse_file(file).expect("couldn't convert the input wat to Wasm");
     let mut module = Module::parse(&buff, false).expect("Unable to parse module");
 
-    module.convert_local_fn_to_import(
-        FunctionID(3),
-        "wirm".to_string(),
-        "better".to_string(),
-        TypeID(2),
-    );
+    module.convert_local_fn_to_import(FunctionID(3), "wirm", "better", TypeID(2));
 
     check_validity(
         file,
@@ -411,24 +396,9 @@ fn test_all_local_to_import() {
     let buff = wat::parse_file(file).expect("couldn't convert the input wat to Wasm");
     let mut module = Module::parse(&buff, false).expect("Unable to parse module");
 
-    module.convert_local_fn_to_import(
-        FunctionID(3),
-        "all".to_string(),
-        "local".to_string(),
-        TypeID(2),
-    );
-    module.convert_local_fn_to_import(
-        FunctionID(4),
-        "to".to_string(),
-        "import".to_string(),
-        TypeID(2),
-    );
-    module.convert_local_fn_to_import(
-        FunctionID(5),
-        "please".to_string(),
-        "work".to_string(),
-        TypeID(2),
-    );
+    module.convert_local_fn_to_import(FunctionID(3), "all", "local", TypeID(2));
+    module.convert_local_fn_to_import(FunctionID(4), "to", "import", TypeID(2));
+    module.convert_local_fn_to_import(FunctionID(5), "please", "work", TypeID(2));
 
     check_validity(
         file,
@@ -445,18 +415,8 @@ fn test_some_local_to_import() {
     let buff = wat::parse_file(file).expect("couldn't convert the input wat to Wasm");
     let mut module = Module::parse(&buff, false).expect("Unable to parse module");
 
-    module.convert_local_fn_to_import(
-        FunctionID(3),
-        "all".to_string(),
-        "local".to_string(),
-        TypeID(2),
-    );
-    module.convert_local_fn_to_import(
-        FunctionID(4),
-        "to".to_string(),
-        "import".to_string(),
-        TypeID(2),
-    );
+    module.convert_local_fn_to_import(FunctionID(3), "all", "local", TypeID(2));
+    module.convert_local_fn_to_import(FunctionID(4), "to", "import", TypeID(2));
 
     check_validity(
         file,
@@ -488,24 +448,9 @@ fn test_all_local_to_import_all_import_to_local() {
     third_builder.drop();
     third_builder.replace_import_in_module(&mut module, ImportsID(2));
 
-    module.convert_local_fn_to_import(
-        FunctionID(3),
-        "all".to_string(),
-        "local".to_string(),
-        TypeID(2),
-    );
-    module.convert_local_fn_to_import(
-        FunctionID(4),
-        "to".to_string(),
-        "import".to_string(),
-        TypeID(2),
-    );
-    module.convert_local_fn_to_import(
-        FunctionID(5),
-        "please".to_string(),
-        "work".to_string(),
-        TypeID(2),
-    );
+    module.convert_local_fn_to_import(FunctionID(3), "all", "local", TypeID(2));
+    module.convert_local_fn_to_import(FunctionID(4), "to", "import", TypeID(2));
+    module.convert_local_fn_to_import(FunctionID(5), "please", "work", TypeID(2));
 
     check_validity(
         file,
@@ -522,7 +467,7 @@ fn test_add_fns_init_exprs() {
     let mut module = Module::parse(&buff, false).expect("Unable to parse module");
 
     // add first import func
-    let (..) = module.add_import_func("test0".to_string(), "func0".to_string(), TypeID(4));
+    let (..) = module.add_import_func("test0", "func0", TypeID(4));
 
     // add first local func
     let mut first_builder = FunctionBuilder::new(&[], &[]);
@@ -554,7 +499,7 @@ fn test_add_imports_and_local_fns() {
     let mut module = Module::parse(&buff, false).expect("Unable to parse module");
 
     // add first import func
-    let (fid, ..) = module.add_import_func("test0".to_string(), "func0".to_string(), TypeID(2));
+    let (fid, ..) = module.add_import_func("test0", "func0", TypeID(2));
 
     // add first local func
     let mut first_builder = FunctionBuilder::new(&[], &[]);
@@ -571,7 +516,7 @@ fn test_add_imports_and_local_fns() {
     sec_builder.finish_module(&mut module);
 
     // add second import func
-    module.add_import_func("test1".to_string(), "func1".to_string(), TypeID(2));
+    module.add_import_func("test1", "func1", TypeID(2));
     check_validity(
         file,
         &mut module,
@@ -627,7 +572,7 @@ fn test_elem_reindexing() {
     // Add an import of a different type. Then the table will have entries of
     // the wrong type unless the element section is reindexed.
     let ty_id = module.types.add_func_type(&[DataType::I32], &[]);
-    let _ = module.add_import_func("".to_string(), "".to_string(), ty_id);
+    let _ = module.add_import_func("", "", ty_id);
     validate(&module.encode(), &output_path).unwrap();
 
     // Run the check function to assert that entries in the table have the expected types.


### PR DESCRIPTION
This removes the explicit leaking of `String`s that's done when adding imports, by having the functions take `&str` arguments instead. The `Import` type remains unchanged.